### PR TITLE
Refactoring cmake-tree and library build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build/
 bin/
+lib/
 *.txt
 *.sh
 .vscode

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,29 +2,14 @@ project(TDE)
 
 cmake_minimum_required(VERSION 3.16)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/lib)
 
-add_library(core OBJECT ${CMAKE_SOURCE_DIR}/core/core.cpp)
 
-add_library(fft OBJECT
-            ${CMAKE_SOURCE_DIR}/fft/fft_forward_class.cpp
-            ${CMAKE_SOURCE_DIR}/fft/fft_reverse_class.cpp)
-target_include_directories(fft PRIVATE ${CMAKE_SOURCE_DIR}/core)
-
-add_library(TDE_lib OBJECT
-            ${CMAKE_SOURCE_DIR}/TDE/TDE_class.cpp)
-target_include_directories(TDE_lib PRIVATE ${CMAKE_SOURCE_DIR}/core)
-
-add_library(GCC_lib OBJECT
-            ${CMAKE_SOURCE_DIR}/GCC/GCC_class.cpp)
-target_include_directories(GCC_lib PRIVATE  ${CMAKE_SOURCE_DIR}/fft
-                                            ${CMAKE_SOURCE_DIR}/core
-                                            ${CMAKE_SOURCE_DIR}/TDE)
-
-add_library(GPS_lib OBJECT
-            ${CMAKE_SOURCE_DIR}/GPS/GPS_class.cpp)
-target_include_directories(GPS_lib PRIVATE  ${CMAKE_SOURCE_DIR}/fft
-                                            ${CMAKE_SOURCE_DIR}/core
-                                            ${CMAKE_SOURCE_DIR}/TDE)
+add_subdirectory(core)
+add_subdirectory(fft)
+add_subdirectory(TDE)
+add_subdirectory(GCC)
+add_subdirectory(GPS)
 
 add_executable(tde ${CMAKE_SOURCE_DIR}/src/main.cpp)
 target_include_directories(tde PRIVATE  ${CMAKE_SOURCE_DIR}/GPS

--- a/GCC/CMakeLists.txt
+++ b/GCC/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(GCC)
+
+cmake_minimum_required(VERSION 3.16)
+
+add_library(GCC_lib STATIC
+            ${CMAKE_SOURCE_DIR}/GCC/GCC_class.cpp)
+target_include_directories(GCC_lib PRIVATE  ${CMAKE_SOURCE_DIR}/fft
+                                            ${CMAKE_SOURCE_DIR}/core
+                                            ${CMAKE_SOURCE_DIR}/TDE)

--- a/GPS/CMakeLists.txt
+++ b/GPS/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(GPS)
+
+cmake_minimum_required(VERSION 3.16)
+
+add_library(GPS_lib STATIC
+            ${CMAKE_SOURCE_DIR}/GPS/GPS_class.cpp)
+target_include_directories(GPS_lib PRIVATE  ${CMAKE_SOURCE_DIR}/fft
+                                            ${CMAKE_SOURCE_DIR}/core
+                                            ${CMAKE_SOURCE_DIR}/TDE)

--- a/TDE/CMakeLists.txt
+++ b/TDE/CMakeLists.txt
@@ -1,0 +1,7 @@
+project(TDE_BASIC)
+
+cmake_minimum_required(VERSION 3.16)
+
+add_library(TDE_lib STATIC
+            ${CMAKE_SOURCE_DIR}/TDE/TDE_class.cpp)
+target_include_directories(TDE_lib PRIVATE ${CMAKE_SOURCE_DIR}/core)

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1,0 +1,5 @@
+project(CORE)
+
+cmake_minimum_required(VERSION 3.16)
+
+add_library(core STATIC ${CMAKE_SOURCE_DIR}/core/core.cpp)

--- a/fft/CMakeLists.txt
+++ b/fft/CMakeLists.txt
@@ -1,0 +1,9 @@
+project(FFT)
+
+cmake_minimum_required(VERSION 3.16)
+
+
+add_library(fft STATIC
+            ${CMAKE_SOURCE_DIR}/fft/fft_forward_class.cpp
+            ${CMAKE_SOURCE_DIR}/fft/fft_reverse_class.cpp)
+target_include_directories(fft PRIVATE ${CMAKE_SOURCE_DIR}/core)


### PR DESCRIPTION
Refactoring cmake-tree and library build - now libraries are built as static and put in "lib/".