### PR TITLE
Refactoring of singletones

### DIFF
--- a/cmd_util/main.cpp
+++ b/cmd_util/main.cpp
@@ -109,7 +109,7 @@ int main(int argc, char* argv[])
 
 static void SetUpEnvironmentByArgs(int argc, char* argv[])
 {
-    std::shared_ptr<program_environment> pe = program_environment::GetInstance();
+    auto pe = program_environment::GetInstance();
 
     const char* progName = *argv;
     --argc;

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -6,7 +6,6 @@
 
 # include <string>
 # include <mutex>
-# include <memory>
 # include <cstdint>
 
 ///@defgroup utility_helpers
@@ -44,7 +43,7 @@ public:
      *
      * @return std::shared_ptr<logger> Instance of logger.
      */
-    static std::shared_ptr<logger> GetInstance();
+    static logger* GetInstance();
 
     /**
      * @brief Set target trace path.
@@ -92,11 +91,10 @@ public:
      * @throws std::runtime_error In case of logger was not initialized.
      */
     void LogMessage( EVENTS event, const char* file, const int line, const char* message );
-    ~logger();
 
 private:
-    static std::shared_ptr<logger> _logger;
     logger();
+    ~logger();
     bool _isInitialized;
     std::mutex _traceMutex;
     std::string _trace;

--- a/include/logger/logger.hpp
+++ b/include/logger/logger.hpp
@@ -41,7 +41,7 @@ public:
     /**
      * @brief Get the Instance object.
      *
-     * @return std::shared_ptr<logger> Instance of logger.
+     * @return logger* Instance of logger.
      */
     static logger* GetInstance();
 

--- a/include/util_helper/program_environment.hpp
+++ b/include/util_helper/program_environment.hpp
@@ -1,8 +1,6 @@
 #ifndef PROGRAMM_ENVORINMENT_HPP
 # define PROGRAMM_ENVORINMENT_HPP
 
-# include <memory>
-
 # include <TDE/TDE_class.hpp>
 
 ///@defgroup utility_helpers
@@ -29,7 +27,6 @@ typedef enum
 class program_environment
 {
 private:
-    static std::shared_ptr<program_environment> _pe;
     uint16_t _window_size;
     uint16_t _sample_rate;
     uint16_t _window_avrg_num;
@@ -37,18 +34,18 @@ private:
     weighting_func _weight_fn;
     bool _isExecutable;
     program_environment();
+    ~program_environment();
 
 public:
-    ~program_environment();
     program_environment(program_environment* pe) = delete;
     void operator = (const program_environment*) = delete;
 
     /**
      * @brief Get the Instance object
      *
-     * @return std::shared_ptr<program_environment> instance of manager object
+     * @return program_environment* instance of manager object
      */
-    static std::shared_ptr<program_environment> GetInstance();
+    static program_environment* GetInstance();
 
     /**
      * @brief Set the size of windows to process.

--- a/logger/logger.cpp
+++ b/logger/logger.cpp
@@ -2,13 +2,10 @@
 #include <iostream>
 #include <logger/logger.hpp>
 
-std::shared_ptr<logger> logger::GetInstance()
+logger* logger::GetInstance()
 {
-    if( !_logger.get() )
-    {
-        _logger.reset(new logger);
-    }
-    return _logger;
+    static logger _logger;
+    return &_logger;
 }
 
 logger::logger() :
@@ -126,5 +123,3 @@ bool operator ! (EVENTS ev)
 {
     return ( 0 == static_cast<std::underlying_type<EVENTS>::type>(ev) );
 }
-
-std::shared_ptr<logger> logger::_logger( nullptr );

--- a/test/calc_test.cpp
+++ b/test/calc_test.cpp
@@ -33,7 +33,7 @@ void calc_test::SetUp()
 {
     vec1.resize(DEFAULT_WINDOW_SIZE);
     vec2.resize(DEFAULT_WINDOW_SIZE);
-    std::shared_ptr<PE> pe = PE::GetInstance();
+    auto pe = PE::GetInstance();
     ASSERT_NO_THROW(pe->SetWindowSize(DEFAULT_WINDOW_SIZE));
     ASSERT_NO_THROW(pe->SetSampleRate(DEFAULT_SAMPLE_RATE));
     ASSERT_NO_THROW(pe->SetWeightingFunction(std::get<0>(GetParam())));

--- a/util_helper/program_environment.cpp
+++ b/util_helper/program_environment.cpp
@@ -20,13 +20,10 @@ program_environment::program_environment() :
 program_environment::~program_environment()
 {}
 
-std::shared_ptr<program_environment> program_environment::GetInstance()
+program_environment* program_environment::GetInstance()
 {
-    if( _pe.get() == nullptr )
-    {
-        _pe.reset(new program_environment());
-    }
-    return _pe;
+    static program_environment _pe;
+    return &_pe;
 }
 
 void program_environment::SetWindowSize(uint16_t window_size)
@@ -109,5 +106,3 @@ bool program_environment::isExecutable()
 {
     return _isExecutable;
 }
-
-std::shared_ptr<program_environment> program_environment::_pe(nullptr);


### PR DESCRIPTION
- Instance methods return raw pointer insted of std::shared_ptr
- Use static variable in Instace methods instead of global static objects