### PR TITLE
Remove redundant allocations in GPS_GRZ meth, memory benchmark

### DIFF
--- a/TDE/GCC_class.cpp
+++ b/TDE/GCC_class.cpp
@@ -17,8 +17,20 @@ GCC::GCC(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     forward(_size),
     reverse(_size)
 {
+    fur_1.resize(size/2+1);
+    fur_2.resize(size/2+1);
+    fur_1_2.resize(size/2+1);
+    fur_1_2_sum.resize(size/2+1);
+
+    ampl1.resize(size/2+1);
+    ampl2.resize(size/2+1);
+    ampl1_sum.resize(size/2+1);
+    ampl2_sum.resize(size/2+1);
+
     corr_func.resize(size);
     PHAT_func.resize(size/2+1);
+
+    clear_inner();
     TRACE_EVENT(EVENTS::CREATE, "success");
 }
 

--- a/TDE/GPS_GRZ_class.cpp
+++ b/TDE/GPS_GRZ_class.cpp
@@ -17,7 +17,9 @@ using namespace logger;
 
 GPS_GRZ::GPS_GRZ(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     iTDE(_size, _rate, _w_func),
-    forward(_size)
+    forward(_size,
+            (size/2+1.) / sample_rate * BOTTOM_FREQ_BOUND,
+            (size/2+1.) / sample_rate * UPPER_FREQ_BOUND)
 {
     lowerBound = (size/2+1.) / sample_rate * BOTTOM_FREQ_BOUND;
     upperBound = (size/2+1.) / sample_rate * UPPER_FREQ_BOUND;
@@ -40,8 +42,6 @@ GPS_GRZ::GPS_GRZ(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     ampl2_sum.resize(diff);
 
     cross_phase_spectrum.resize(diff);
-
-    forward.SetBounds( lowerBound, upperBound );
 
     TRACE_EVENT(EVENTS::CREATE, "success");
 }

--- a/TDE/GPS_GRZ_class.cpp
+++ b/TDE/GPS_GRZ_class.cpp
@@ -27,10 +27,6 @@ GPS_GRZ::GPS_GRZ(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     auto diff = upperBound - lowerBound;
     TRACE_EVENT( EVENTS::DEBUG, std::to_string( diff ).c_str() );
 
-    /**
-     * Force resize buffers to reduced size;
-     *
-     */
     fur_1.resize(diff);
     fur_2.resize(diff);
     fur_1_2.resize(diff);
@@ -43,6 +39,7 @@ GPS_GRZ::GPS_GRZ(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
 
     cross_phase_spectrum.resize(diff);
 
+    clear_inner();
     TRACE_EVENT(EVENTS::CREATE, "success");
 }
 

--- a/TDE/GPS_class.cpp
+++ b/TDE/GPS_class.cpp
@@ -20,7 +20,19 @@ GPS::GPS(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     iTDE(_size, _rate, _w_func),
     forward(_size)
 {
+    fur_1.resize(size/2+1);
+    fur_2.resize(size/2+1);
+    fur_1_2.resize(size/2+1);
+    fur_1_2_sum.resize(size/2+1);
+
+    ampl1.resize(size/2+1);
+    ampl2.resize(size/2+1);
+    ampl1_sum.resize(size/2+1);
+    ampl2_sum.resize(size/2+1);
+
     cross_phase_spectrum.resize(size/2+1);
+
+    clear_inner();
     TRACE_EVENT(EVENTS::CREATE, "success");
 }
 

--- a/TDE/TDE_class.cpp
+++ b/TDE/TDE_class.cpp
@@ -30,17 +30,6 @@ iTDE::iTDE(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func) :
     {
         throw std::logic_error("Sampling rate must be greater than 0");
     }
-
-    fur_1.resize(size/2+1);
-    fur_2.resize(size/2+1);
-    fur_1_2.resize(size/2+1);
-    fur_1_2_sum.resize(size/2+1);
-
-    ampl1.resize(size/2+1);
-    ampl2.resize(size/2+1);
-    ampl1_sum.resize(size/2+1);
-    ampl2_sum.resize(size/2+1);
-    clear_inner();
 }
 
 iTDE::~iTDE()
@@ -95,7 +84,7 @@ void iTDE::normalize_sum()
     {
         TRACE_EVENT( logger::EVENTS::ERROR, "Inconsistent sizes of amplitude and fourier buffers" );
     }
-    for (size_t i = 0; i < size/2+1; ++i)
+    for (size_t i = 0; i < fur_1_2_sum.size(); ++i)
     {
         fur_1_2_sum[i] /= update_count;
         ampl1_sum[i] /= update_count;

--- a/fft/goerzel.c
+++ b/fft/goerzel.c
@@ -73,11 +73,8 @@ int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 #endif
     tf->res = NAN;
 
-    if( isnan( tf->sin_ ) ||
-        isnan( tf->cos_ ) )
-    {
-        return 0;
-    }
+    assert( !isnan( tf->sin_ ) );
+    assert( !isnan( tf->cos_ ) );
 
     return 1;
 }

--- a/fft/goerzel.c
+++ b/fft/goerzel.c
@@ -54,7 +54,7 @@ void GoerzelTF_destroy( GoerzelTF* tf )
     free( tf );
 }
 
-int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
+void GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 {
     assert( tf );
 
@@ -75,22 +75,16 @@ int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 
     assert( !isnan( tf->sin_ ) );
     assert( !isnan( tf->cos_ ) );
-
-    return 1;
 }
 
-int GoerzelTF_update( GoerzelTF* tf, double data )
+void GoerzelTF_update( GoerzelTF* tf, double data )
 {
     assert( tf );
-    assert( !isnan( tf->sin_ ) );;
-    assert( !isnan( tf->cos_ ) );
     ++tf->updateCount;
 
     tf->q2 = tf->q1;
     tf->q1 = tf->q0;
     tf->q0 = 2 * tf->cos_ * tf->q1 - tf->q2 + data;
-
-    return 1;
 }
 
 double _Complex GoerzelTF_result( GoerzelTF* tf )

--- a/fft/goerzel.c
+++ b/fft/goerzel.c
@@ -64,6 +64,8 @@ void GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 #ifdef ENABLE_PRECALC
     assert( idx >= tf->firstFreqIndex_ );
     assert( idx <= tf->firstFreqIndex_ + tf->freqIndexWidth_ );
+    assert( tf->preCalcTable[ SIN_TABLE ] );
+    assert( tf->preCalcTable[ COS_TABLE ] );
     tf->sin_ = tf->preCalcTable[ SIN_TABLE ][ idx - tf->firstFreqIndex_ ];
     tf->cos_ = tf->preCalcTable[ COS_TABLE ][ idx - tf->firstFreqIndex_ ];
 #else
@@ -111,6 +113,8 @@ int GoerzelTF_precalc( GoerzelTF* tf, size_t firstIdx, size_t numSamples )
     tf->firstFreqIndex_ = firstIdx;
     tf->freqIndexWidth_ = numSamples;
 
+    free( tf->preCalcTable[ SIN_TABLE ] );
+    free( tf->preCalcTable[ COS_TABLE ] );
     tf->preCalcTable[ SIN_TABLE ] = ( double* )malloc( sizeof( double ) * numSamples );
     tf->preCalcTable[ COS_TABLE ] = ( double* )malloc( sizeof( double ) * numSamples );
 

--- a/fft/goerzel.c
+++ b/fft/goerzel.c
@@ -20,6 +20,7 @@ struct GoerzTf_st
 
 #ifdef ENABLE_PRECALC
     double* preCalcTable[ 2 ];
+    size_t firstFreqIndex_, freqIndexWidth_;
 #endif
 
     size_t numSamples;
@@ -33,28 +34,12 @@ GoerzelTF* GoerzelTF_create( size_t numSamples )
     {
         tf->numSamples = numSamples;
         tf->updateCount = 0ul;
+        tf->res = NAN;
+        tf->sin_ = NAN;
+        tf->cos_ = NAN;
 #ifdef ENABLE_PRECALC
-        tf->preCalcTable[ SIN_TABLE ] = ( double* )malloc( sizeof( double ) * ( numSamples / 2 + 1 ) );
-        tf->preCalcTable[ COS_TABLE ] = ( double* )malloc( sizeof( double ) * ( numSamples / 2 + 1 ) );
-
-        if( !tf->preCalcTable[ SIN_TABLE ] || !tf->preCalcTable[ COS_TABLE ] )
-        {
-            GoerzelTF_destroy( tf );
-            tf = NULL;
-        }
-
-        for( size_t i = 0; i < numSamples / 2 + 1; ++i )
-        {
-            double omega = 2 * M_PI * i / numSamples;
-            tf->preCalcTable[ SIN_TABLE ][ i ] = sin( omega );
-            tf->preCalcTable[ COS_TABLE ][ i ] = cos( omega );
-            if( isnan( tf->preCalcTable[ SIN_TABLE ][ i ] ) ||
-                isnan( tf->preCalcTable[ COS_TABLE ][ i ] ) )
-            {
-                GoerzelTF_destroy( tf );
-                tf = NULL;
-            }
-        }
+        tf->preCalcTable[ SIN_TABLE ] = NULL;
+        tf->preCalcTable[ COS_TABLE ] = NULL;
 #endif
     }
     return tf;
@@ -72,15 +57,17 @@ void GoerzelTF_destroy( GoerzelTF* tf )
 int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 {
     assert( tf );
-    assert( idx < tf->numSamples / 2 + 1 );
 
     tf->q0 = 0.0;
     tf->q1 = 0.0;
     tf->q2 = 0.0;
 #ifdef ENABLE_PRECALC
-    tf->sin_ = tf->preCalcTable[ SIN_TABLE ][ idx ];
-    tf->cos_ = tf->preCalcTable[ COS_TABLE ][ idx ];
+    assert( idx >= tf->firstFreqIndex_ );
+    assert( idx <= tf->firstFreqIndex_ + tf->freqIndexWidth_ );
+    tf->sin_ = tf->preCalcTable[ SIN_TABLE ][ idx - tf->firstFreqIndex_ ];
+    tf->cos_ = tf->preCalcTable[ COS_TABLE ][ idx - tf->firstFreqIndex_ ];
 #else
+    assert( idx < tf->numSamples / 2 + 1 );
     tf->sin_ = sin( 2 * M_PI * idx / tf->numSamples );
     tf->cos_ = cos( 2 * M_PI * idx / tf->numSamples );
 #endif
@@ -98,6 +85,8 @@ int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx )
 int GoerzelTF_update( GoerzelTF* tf, double data )
 {
     assert( tf );
+    assert( !isnan( tf->sin_ ) );;
+    assert( !isnan( tf->cos_ ) );
     ++tf->updateCount;
 
     tf->q2 = tf->q1;
@@ -119,4 +108,41 @@ size_t GoerzelTF_get_update_count( GoerzelTF* tf )
 {
     assert( tf );
     return tf->updateCount;
+}
+
+int GoerzelTF_precalc( GoerzelTF* tf, size_t firstIdx, size_t numSamples )
+{
+#ifdef ENABLE_PRECALC
+    assert( tf );
+    assert( firstIdx <= tf->numSamples );
+    assert( firstIdx + numSamples <= tf->numSamples / 2 + 1 );
+
+    tf->firstFreqIndex_ = firstIdx;
+    tf->freqIndexWidth_ = numSamples;
+
+    tf->preCalcTable[ SIN_TABLE ] = ( double* )malloc( sizeof( double ) * numSamples );
+    tf->preCalcTable[ COS_TABLE ] = ( double* )malloc( sizeof( double ) * numSamples );
+
+    if( !tf->preCalcTable[ SIN_TABLE ] || !tf->preCalcTable[ COS_TABLE ] )
+    {
+        return 0;
+    }
+
+    for( size_t i = 0; i < tf->freqIndexWidth_; ++i )
+    {
+        double omega = 2 * M_PI * ( tf->firstFreqIndex_ + i ) / tf->numSamples;
+        if( isnan( omega ) )
+        {
+            return 0;
+        }
+        tf->preCalcTable[ SIN_TABLE ][ i ] = sin( omega );
+        tf->preCalcTable[ COS_TABLE ][ i ] = cos( omega );
+    }
+    return 1;
+#else
+    ( void )tf;
+    ( void )firstIdx;
+    ( void )numSamples;
+    return 1;
+#endif // ENABLE_PRECALC
 }

--- a/fft/grz_forward_class.cpp
+++ b/fft/grz_forward_class.cpp
@@ -20,8 +20,6 @@ Forward::Forward(size_t _size) :
     }
 
     real_array.resize(size);
-    fourier_image.resize(size/2+1);
-    goerzHandle = GoerzelTF_create( size );
     TRACE_EVENT(EVENTS::CREATE, "fft_forward class created");
 }
 
@@ -35,7 +33,7 @@ void Forward::SetBounds( size_t lowerBound, size_t upperBound )
 {
     if( lowerBound > size/2u+1u || upperBound > size/2u+1u )
     {
-        throw std::logic_error( "Bounds must be less then siz+1" );
+        throw std::logic_error( "Bounds must be less then size+1" );
     }
 
     if( lowerBound > upperBound )
@@ -44,6 +42,15 @@ void Forward::SetBounds( size_t lowerBound, size_t upperBound )
     }
     lowerBound_ = lowerBound;
     upperBound_ = upperBound;
+    goerzHandle = GoerzelTF_create( size );
+    if( !goerzHandle )
+    {
+        throw std::runtime_error( "Could not create Goerzel transform handle" );
+    }
+    if( !GoerzelTF_precalc( goerzHandle, lowerBound_, upperBound_ ) )
+    {
+        throw std::runtime_error( "Failed to evaluate precalculation" );
+    }
 
     fourier_image.resize( upperBound - lowerBound );
 }
@@ -56,12 +63,14 @@ void Forward::Execute() noexcept
         if( !GoerzelTF_set_freq_idx( goerzHandle, freqIndex ) )
         {
             TRACE_EVENT( EVENTS::ERROR, "GoerzelTF_set_freq_idx() failed" );
+            return;
         }
         for( auto sample : real_array )
         {
             if( !GoerzelTF_update( goerzHandle, sample ) )
             {
                 TRACE_EVENT( EVENTS::ERROR, "GoerzelTF_update() failed" );
+                return;
             }
         }
         harmonica = GoerzelTF_result( goerzHandle );
@@ -92,5 +101,5 @@ void Forward::SetReal(const std::vector<double>& _real) noexcept
 
 void Forward::GetFourierImage(std::vector<std::complex<double>>& _fourier) noexcept
 {
-    memcpy(&_fourier[0], &fourier_image[0], sizeof(std::complex<double>)*(size/2+1));
+    memcpy(&_fourier[0], &fourier_image[0], sizeof(std::complex<double>)*(upperBound_ - lowerBound_));
 }

--- a/fft/grz_forward_class.cpp
+++ b/fft/grz_forward_class.cpp
@@ -25,7 +25,7 @@ Forward::Forward(size_t _size, size_t lowerBound, size_t upperBound) :
         throw std::logic_error( "Bounds must be less then size+1" );
     }
 
-    if( lowerBound > upperBound )
+    if( lowerBound >= upperBound )
     {
         throw std::logic_error( "Lower bound is greater then upper" );
     }

--- a/fft/grz_forward_class.cpp
+++ b/fft/grz_forward_class.cpp
@@ -59,11 +59,7 @@ void Forward::Execute() noexcept
     size_t freqIndex = lowerBound_;
     for( auto& harmonica : fourier_image )
     {
-        if( !GoerzelTF_set_freq_idx( goerzHandle.get(), freqIndex ) )
-        {
-            TRACE_EVENT( EVENTS::ERROR, "GoerzelTF_set_freq_idx() failed" );
-            return;
-        }
+        GoerzelTF_set_freq_idx( goerzHandle.get(), freqIndex );
         for( auto sample : real_array )
         {
             GoerzelTF_update( goerzHandle.get(), sample );

--- a/include/FFT/grz_forward_class.hpp
+++ b/include/FFT/grz_forward_class.hpp
@@ -3,10 +3,11 @@
 
 #pragma once
 
-# include <cstdint>
-# include <vector>
-# include <complex>
-# include <goerzel.h>
+#include <cstdint>
+#include <vector>
+#include <complex>
+#include <memory>
+#include <goerzel.h>
 
 ///@defgroup FFT_interface
 ///@addtogroup FFT_interface
@@ -25,6 +26,8 @@ namespace cpu
 namespace grz
 {
 
+using GoerzPtr = std::unique_ptr< GoerzelTF, decltype( &GoerzelTF_destroy ) >;
+
 /**
  * @class Transform
  * @brief This class implements direct Fast Fourier Transform.
@@ -35,20 +38,18 @@ namespace grz
 class Forward
 {
 public:
-
     Forward() = delete;
     Forward(Forward&) = delete;
-    void operator = (const Forward&) = delete;
+    Forward operator = (const Forward&) = delete;
 
     /**
      * @brief Construct a new fft forward object
      *
-     * @param _size     Number of samples of real input samples.
+     * @param size     Number of samples of real input samples.
      */
-    Forward(size_t _size);
+    Forward(size_t size);
+    Forward(size_t size, size_t lowerBound, size_t upperBound);
     ~Forward();
-
-    void SetBounds( size_t lowerBound, size_t upperBound );
 
     /**
      * @brief Execute direct transform of arrays passed in set_real().
@@ -81,7 +82,7 @@ private:
     size_t size = 0;
     size_t lowerBound_ = 0;
     size_t upperBound_ = 0;
-    GoerzelTF* goerzHandle = nullptr;
+    GoerzPtr goerzHandle{ nullptr, GoerzelTF_destroy };
     std::vector<double> real_array;
     std::vector<std::complex<double>> fourier_image;
     void NormalizeFur();

--- a/include/TDE/GCC_class.hpp
+++ b/include/TDE/GCC_class.hpp
@@ -33,8 +33,8 @@ class GCC final : public iTDE
 {
 public:
     GCC() = delete;
-    GCC(GCC*) = delete;
-    void operator = (const GCC*) = delete;
+    GCC(const GCC&) = delete;
+    void operator = (const GCC&) = delete;
     GCC(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func);
     ~GCC();
 

--- a/include/TDE/GPS_GRZ_class.hpp
+++ b/include/TDE/GPS_GRZ_class.hpp
@@ -33,7 +33,7 @@ class GPS_GRZ final : public iTDE
 {
 public:
     GPS_GRZ() = delete;
-    GPS_GRZ(GPS_GRZ&) = delete;
+    GPS_GRZ(const GPS_GRZ&) = delete;
     void operator = (const GPS_GRZ&) = delete;
     GPS_GRZ(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func);
     ~GPS_GRZ();

--- a/include/TDE/GPS_class.hpp
+++ b/include/TDE/GPS_class.hpp
@@ -32,8 +32,8 @@ class GPS final : public iTDE
 {
 public:
     GPS() = delete;
-    GPS(GPS*) = delete;
-    void operator = (const GPS*) = delete;
+    GPS(const GPS&) = delete;
+    void operator = (const GPS&) = delete;
     GPS(size_t _size, size_t _rate, WEIGHTING_FN_TYPE _w_func);
     ~GPS();
 

--- a/include/TDE/TDE_class.hpp
+++ b/include/TDE/TDE_class.hpp
@@ -39,8 +39,8 @@ class iTDE
 {
 public:
     iTDE() = delete;
-    iTDE(iTDE*) = delete;
-    void operator = (const iTDE*) = delete;
+    iTDE(const iTDE&) = delete;
+    void operator = (const iTDE&) = delete;
 
     /**
      * @brief Construct a new TDE object.

--- a/internal_include/goerzel.h
+++ b/internal_include/goerzel.h
@@ -20,6 +20,8 @@ double _Complex GoerzelTF_result( GoerzelTF* tf );
 
 size_t GoerzelTF_get_update_count( GoerzelTF* tf );
 
+int GoerzelTF_precalc( GoerzelTF* tf, size_t firstIdx, size_t numSamples );
+
 #ifdef __cplusplus
 }
 #endif // _cplusplus

--- a/internal_include/goerzel.h
+++ b/internal_include/goerzel.h
@@ -12,9 +12,9 @@ GoerzelTF* GoerzelTF_create( size_t numSamples );
 
 void GoerzelTF_destroy( GoerzelTF* tf );
 
-int GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx );
+void GoerzelTF_set_freq_idx( GoerzelTF* tf, size_t idx );
 
-int GoerzelTF_update( GoerzelTF* tf, double data );
+void GoerzelTF_update( GoerzelTF* tf, double data );
 
 double _Complex GoerzelTF_result( GoerzelTF* tf );
 

--- a/test/calc_test.cpp
+++ b/test/calc_test.cpp
@@ -49,7 +49,7 @@ void calc_test::SetUp()
 void calc_test::TearDown()
 {}
 
-TEST_P(calc_test, leak_test)
+TEST_P(calc_test, UpdateConcludeExpectSuccess)
 {
     ASSERT_NO_THROW(calc.reset(PE::GetInstance().CreateCalculator()));
     ASSERT_NE(calc.get(), nullptr);

--- a/test/calc_test.cpp
+++ b/test/calc_test.cpp
@@ -11,10 +11,6 @@ using namespace tde;
 using namespace utility_helpers::program_environment;
 using PE = ProgramEnvironment;
 
-static const uint16_t DEFAULT_SAMPLE_RATE = 44100;
-static const uint16_t DEFAULT_WINDOW_SIZE = 1 << 10;
-static const uint16_t DEFAULT_AVRG_NUM = 5;
-
 class calc_test : public testing::TestWithParam<std::tuple<WEIGHTING_FN_TYPE, TDE_METH>>
 {
 public:
@@ -31,19 +27,21 @@ public:
 void calc_test::SetUp()
 {
     std::srand( std::time(nullptr));
-    vec1.resize(DEFAULT_WINDOW_SIZE);
-    vec2.resize(DEFAULT_WINDOW_SIZE);
+    auto& pe = ProgramEnvironment::GetInstance();
+
+    vec1.resize(pe.GetWindowSize());
+    vec2.resize(pe.GetWindowSize());
+
     for( auto& sample : vec1 )
     {
         sample = static_cast<double>( std::rand() ) / RAND_MAX - 0.5;
     }
     std::memcpy( &vec2[ 0 ], &vec1[ 0 ], sizeof( double ) * vec1.size() );
-    auto& pe = ProgramEnvironment::GetInstance();
-    ASSERT_NO_THROW(pe.SetWindowSize(DEFAULT_WINDOW_SIZE));
-    ASSERT_NO_THROW(pe.SetSampleRate(DEFAULT_SAMPLE_RATE));
+
+    // override some parameters
     ASSERT_NO_THROW(pe.SetWeightingFunction(std::get<0>(GetParam())));
     ASSERT_NO_THROW(pe.SetMethodTDE(std::get<1>(GetParam())));
-    ASSERT_NO_THROW(pe.SetWinAvrgNum(DEFAULT_AVRG_NUM));
+    ASSERT_NO_THROW(pe.SetWinAvrgNum( 5 ));
 }
 
 void calc_test::TearDown()

--- a/test/goerz_test.cpp
+++ b/test/goerz_test.cpp
@@ -10,7 +10,7 @@ using GoerzPtr = std::unique_ptr< GoerzelTF, decltype( &GoerzelTF_destroy ) >;
 
 static const size_t SAMPLES = 1 << 5;
 
-TEST( GoerzTest, test )
+TEST( GoerzTest, UpdateResultExpectSuccess )
 {
     const size_t SAMPLES = 1 << 4;
 
@@ -21,6 +21,7 @@ TEST( GoerzTest, test )
     }
 
     GoerzPtr tf( GoerzelTF_create( SAMPLES ), GoerzelTF_destroy );
+    ASSERT_EQ( 1, GoerzelTF_precalc( tf.get(), 0, SAMPLES / 2 + 1 ) );
 
     for( size_t i = 0; i < SAMPLES / 2 + 1 ; ++i )
     {
@@ -35,7 +36,7 @@ TEST( GoerzTest, test )
     }
 }
 
-TEST( GoerzTest, CmpTest )
+TEST( GoerzTest, Goerzel_VS_fftw3 )
 {
     transform::cpu::fft::Forward fft( SAMPLES );
     transform::cpu::grz::Forward grz( SAMPLES );
@@ -64,10 +65,10 @@ TEST( GoerzTest, CmpTest )
     {
         if( i == 2 || i == 5 || i == 10 )
         {
-            EXPECT_NEAR( fftRes[ i ].real(), grzRes[ i ].real(), 0.0001 );
-            EXPECT_NEAR( fftRes[ i ].imag(), grzRes[ i ].imag(), 0.0001 );
-            EXPECT_NEAR( abs( fftRes[ i ] ), abs( grzRes[ i ] ), 0.0001 );
-            EXPECT_NEAR( arg( fftRes[ i ] ), arg( grzRes[ i ] ), 0.0001 );
+            EXPECT_NEAR( fftRes[ i ].real(), grzRes[ i ].real(), 0.000001 );
+            EXPECT_NEAR( fftRes[ i ].imag(), grzRes[ i ].imag(), 0.000001 );
+            EXPECT_NEAR( abs( fftRes[ i ] ), abs( grzRes[ i ] ), 0.000001 );
+            EXPECT_NEAR( arg( fftRes[ i ] ), arg( grzRes[ i ] ), 0.000001 );
         }
     }
 }

--- a/test/goerz_test.cpp
+++ b/test/goerz_test.cpp
@@ -6,8 +6,6 @@
 #include <FFT/grz_forward_class.hpp>
 #include "goerzel.h"
 
-using GoerzPtr = std::unique_ptr< GoerzelTF, decltype( &GoerzelTF_destroy ) >;
-
 static const size_t SAMPLES = 1 << 5;
 
 TEST( GoerzTest, UpdateResultExpectSuccess )
@@ -20,7 +18,7 @@ TEST( GoerzTest, UpdateResultExpectSuccess )
         sine[ i ] = 10 * sin( 3 * 2 * M_PI * i / SAMPLES);
     }
 
-    GoerzPtr tf( GoerzelTF_create( SAMPLES ), GoerzelTF_destroy );
+    transform::cpu::grz::GoerzPtr tf( GoerzelTF_create( SAMPLES ), GoerzelTF_destroy );
     ASSERT_EQ( 1, GoerzelTF_precalc( tf.get(), 0, SAMPLES / 2 + 1 ) );
 
     for( size_t i = 0; i < SAMPLES / 2 + 1 ; ++i )

--- a/test/goerz_test.cpp
+++ b/test/goerz_test.cpp
@@ -39,8 +39,7 @@ TEST( GoerzTest, UpdateResultExpectSuccess )
 TEST( GoerzTest, Goerzel_VS_fftw3 )
 {
     transform::cpu::fft::Forward fft( SAMPLES );
-    transform::cpu::grz::Forward grz( SAMPLES );
-    grz.SetBounds( 0, SAMPLES / 2 + 1 );
+    transform::cpu::grz::Forward grz( SAMPLES, 0, SAMPLES / 2 + 1 );
 
     std::vector<double> sine( SAMPLES );
     for( size_t i = 0; i < SAMPLES; ++i )

--- a/test/goerz_test.cpp
+++ b/test/goerz_test.cpp
@@ -25,11 +25,10 @@ TEST( GoerzTest, UpdateResultExpectSuccess )
 
     for( size_t i = 0; i < SAMPLES / 2 + 1 ; ++i )
     {
-        ASSERT_EQ( 1, GoerzelTF_set_freq_idx( tf.get(), i ) );
-        ASSERT_NE( tf, nullptr );
+        GoerzelTF_set_freq_idx( tf.get(), i );
         for( auto sample : sine )
         {
-            ASSERT_EQ( 1, GoerzelTF_update( tf.get(), sample ) );
+            GoerzelTF_update( tf.get(), sample );
         }
         std::complex<double> res = GoerzelTF_result( tf.get() );
         ASSERT_EQ( res, res );

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -7,8 +7,8 @@ int main(int argc, char** argv)
     try
     {
         auto& logger_ = logger::Logger::GetInstance();
-        logger_.SetEvents( logger::EVENTS::TDE_CALC | logger::EVENTS::ERROR | logger::EVENTS::DEBUG );
-        logger_.SetTrace(  "log.txt" );
+        logger_.SetEvents( logger::EVENTS::DEBUG );
+        logger_.SetTrace( "log.txt" );
         logger_.Initialize();
     }
     catch( std::exception& e )

--- a/test/main.cpp
+++ b/test/main.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <logger/logger.hpp>
+#include "test_env.hpp"
 
 int main(int argc, char** argv)
 {
@@ -8,7 +9,7 @@ int main(int argc, char** argv)
     {
         auto& logger_ = logger::Logger::GetInstance();
         logger_.SetEvents( logger::EVENTS::DEBUG );
-        logger_.SetTrace( "log.txt" );
+        logger_.SetTrace( "stdout" );
         logger_.Initialize();
     }
     catch( std::exception& e )
@@ -18,5 +19,6 @@ int main(int argc, char** argv)
     }
 #endif
     testing::InitGoogleTest(&argc, argv);
+    testing::AddGlobalTestEnvironment( new TestEnvironment( argc, argv ) );
     return RUN_ALL_TESTS();
 }

--- a/test/mem_bench.sh
+++ b/test/mem_bench.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+# Run command: ./mem_bench.sh > ../_result/bin/mem_res.txt 2>&1
+
 BINARY_DIR=${CWD}../_result/bin
 TEST_NAME=tests
+RES_FILE=${BINARY_DIR}/mem_res_44100.txt
 
-win_sizes=(128 256 512 1024 2048 4096 8192)
+win_sizes=(256 512 1024 2048 4096 8192)
 tde_meths=(GCC GPS GPS_GRZ)
 
 for size in ${win_sizes[*]}

--- a/test/mem_bench.sh
+++ b/test/mem_bench.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+BINARY_DIR=${CWD}../_result/bin
+TEST_NAME=tests
+
+win_sizes=(128 256 512 1024 2048 4096 8192)
+tde_meths=(GCC GPS GPS_GRZ)
+
+for size in ${win_sizes[*]}
+do
+    for meth in ${tde_meths[*]}
+    do
+        echo window size: ${size}       tde meth: ${meth}
+        echo
+        valgrind ${BINARY_DIR}/${TEST_NAME} --win-size ${size} --tde-method ${meth}
+        echo
+        echo ==================================================================
+        echo
+    done
+done

--- a/test/test_env.hpp
+++ b/test/test_env.hpp
@@ -1,0 +1,18 @@
+#include <util_helper/program_environment.hpp>
+#include <gtest/gtest.h>
+
+#pragma once
+
+using namespace utility_helpers::program_environment;
+
+class TestEnvironment : public testing::Environment
+{
+public:
+    TestEnvironment( int argc, char* argv[] )
+    {
+        if( argc > 1 )
+        {
+            ProgramEnvironment::GetInstance().SetUpByArgs(argc, argv);
+        }
+    }
+};

--- a/time_benchmark/main.cpp
+++ b/time_benchmark/main.cpp
@@ -12,7 +12,7 @@ constexpr size_t NUM_BENCH_ITERS = 100;
 int main()
 {
     size_t N[] = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 };
-    size_t diff[] { 3, 4, 5, 6, 7, 8, 10, 12, 15, 20, 25, 30, 35, 40, 50 };
+    size_t diff[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 25, 30, 35, 40, 50 };
 
     TimeBecnmark bench;
 
@@ -27,11 +27,10 @@ int main()
         {
             sample = static_cast<double>( std::rand() ) / RAND_MAX - 0.5;
         }
-        transform::cpu::grz::Forward transform( 1 << N_ );
-        transform.SetReal( data );
         for( auto diff_ : diff )
         {
-            transform.SetBounds( GRZ_INDEX_FIRST, GRZ_INDEX_FIRST + diff_ );
+            transform::cpu::grz::Forward transform( 1 << N_, GRZ_INDEX_FIRST, GRZ_INDEX_FIRST + diff_ );
+            transform.SetReal( data );
             for( size_t i = 0; i < NUM_BENCH_ITERS; ++i )
             {
                 auto begin = std::chrono::steady_clock::now();

--- a/time_benchmark/main.cpp
+++ b/time_benchmark/main.cpp
@@ -17,8 +17,8 @@ constexpr size_t NUM_BENCH_ITERS = 100;
 
 int main()
 {
-    size_t N[] = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 };
-    size_t diff[] { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 25, 30, 35, 40, 50 };
+    [[maybe_unused]]size_t N[] = { 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21 };
+    [[maybe_unused]]size_t diff[] = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12, 15, 20, 25, 30, 35, 40, 50 };
 
     TimeBecnmark bench;
 


### PR DESCRIPTION
* Remove redundant allocations in GRZ_GPS class ctor
* Scripts to geather memory consumption info
* Some other fixes